### PR TITLE
Don't discard error code from rustix::fallocate

### DIFF
--- a/src/unix/sync_impl.rs
+++ b/src/unix/sync_impl.rs
@@ -24,7 +24,7 @@ pub fn allocate(file: &File, len: u64) -> std::io::Result<()> {
         let borrowed_fd = BorrowedFd::borrow_raw(file.as_raw_fd());
         match fallocate(borrowed_fd, FallocateFlags::from_bits_unchecked(0), 0, len) {
             Ok(_) => Ok(()),
-            Err(_) => Err(std::io::Error::last_os_error()),
+            Err(e) => Err(std::io::Error::from_raw_os_error(e.raw_os_error())),
         }
     }
 }


### PR DESCRIPTION
rustix already abstracts around the differences between `fallocate` and `posix_fallocate`, specifically whether the error code is returned directly or through errno.

This will fix `fs4::FileExt::allocate` on platforms that do not have `fallocate` (e.g. FreeBSD), but Linux behavior will stay the same as before