### PR TITLE
Fix compilation on illumos.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ smol-async = ["smol", "async-trait"]
 libc = "0.2"
 
 [target.'cfg(not(windows))'.dependencies]
-rustix = { version = "0.35.7", features = ["fs"] }
+rustix = { version = "0.37.10", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["handleapi", "processthreadsapi", "winerror", "fileapi", "winbase", "std"] }

--- a/src/unix/async_impl.rs
+++ b/src/unix/async_impl.rs
@@ -58,6 +58,7 @@ macro_rules! allocate {
             target_os = "netbsd",
             target_os = "dragonfly",
             target_os = "solaris",
+            target_os = "illumos",
             target_os = "haiku"
         ))]
         pub async fn allocate(file: &$file, len: u64) -> std::io::Result<()> {

--- a/src/unix/sync_impl.rs
+++ b/src/unix/sync_impl.rs
@@ -65,6 +65,7 @@ pub fn allocate(file: &File, len: u64) -> std::io::Result<()> {
     target_os = "netbsd",
     target_os = "dragonfly",
     target_os = "solaris",
+    target_os = "illumos",
     target_os = "haiku",
 ))]
 pub fn allocate(file: &File, len: u64) -> std::io::Result<()> {


### PR DESCRIPTION
Add cases for illumos, following solaris, which it is similar to.

And update to rustix 0.37.10, which fixes a missing `statvfs` on illumos.