### PR TITLE
Port macos/ios `fallocate` code from libc to rustix.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,6 @@ std-async = ["async-std/async-io", "async-trait"]
 tokio-async = ["tokio/fs", "async-trait"]
 smol-async = ["smol", "async-trait"]
 
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
-libc = "0.2"
-
 [target.'cfg(not(windows))'.dependencies]
 rustix = { version = "0.35.7", features = ["fs"] }
 

--- a/src/unix/async_impl.rs
+++ b/src/unix/async_impl.rs
@@ -5,7 +5,11 @@ macro_rules! allocate {
             target_os = "freebsd",
             target_os = "android",
             target_os = "emscripten",
-            target_os = "nacl"
+            target_os = "nacl",
+            target_os = "macos",
+            target_os = "ios",
+            target_os = "watchos",
+            target_os = "tvos"
         ))]
         pub async fn allocate(file: &$file, len: u64) -> std::io::Result<()> {
             use rustix::{
@@ -18,38 +22,6 @@ macro_rules! allocate {
                     Ok(_) => Ok(()),
                     Err(e) => Err(std::io::Error::from_raw_os_error(e.raw_os_error())),
                 }
-            }
-        }
-
-        #[cfg(any(target_os = "macos", target_os = "ios"))]
-        pub async fn allocate(file: &$file, len: u64) -> std::io::Result<()> {
-            let stat = file.metadata().await?;
-
-            if len > stat.blocks() as u64 * 512 {
-                let mut fstore = libc::fstore_t {
-                    fst_flags: libc::F_ALLOCATECONTIG,
-                    fst_posmode: libc::F_PEOFPOSMODE,
-                    fst_offset: 0,
-                    fst_length: len as libc::off_t,
-                    fst_bytesalloc: 0,
-                };
-
-                let ret = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_PREALLOCATE, &fstore) };
-                if ret == -1 {
-                    // Unable to allocate contiguous disk space; attempt to allocate non-contiguously.
-                    fstore.fst_flags = libc::F_ALLOCATEALL;
-                    let ret =
-                        unsafe { libc::fcntl(file.as_raw_fd(), libc::F_PREALLOCATE, &fstore) };
-                    if ret == -1 {
-                        return Err(std::io::Error::last_os_error());
-                    }
-                }
-            }
-
-            if len > stat.size() as u64 {
-                file.set_len(len).await
-            } else {
-                Ok(())
             }
         }
 


### PR DESCRIPTION
Rustix supports `fallocate` on macos/ios/etc. now, so use that instead of having a separate copy of the code for implementing it in terms of the libc APIs.