### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: test all features
-        run: cargo test --all-features
+        # Run sequentially to avoid race condition around file system size
+        run: cargo test --all-features -- --test-threads 1
 
   coverage:
     name: cargo tarpaulin

--- a/src/windows/sync_impl.rs
+++ b/src/windows/sync_impl.rs
@@ -73,7 +73,7 @@ mod test {
             .read(true)
             .write(true)
             .create(true)
-            .open(&path)
+            .open(path)
             .unwrap();
 
         // Multiple exclusive locks fails.
@@ -102,7 +102,7 @@ mod test {
             .read(true)
             .write(true)
             .create(true)
-            .open(&path)
+            .open(path)
             .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.


### PR DESCRIPTION
This fixes Windows tests in CI (due to parallel tests file system info is not deterministic unless tests are running sequentially), but docs are still failing due to `docsrs` configuration option setting causing issues in `tokio` (didn't bother looking into it closer yet)