### PR TITLE
Use valid  SPDX 2.3 license expression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fs4"
 # NB: When modifying, also modify html_root_url in lib.rs
 version = "0.8.1"
 authors = ["Dan Burkert <dan@danburkert.com>", "Al Liu <scygliu1@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = "https://github.com/al8n/fs4-rs"
 documentation = "https://docs.rs/fs4"
 description = "No libc, pure Rust cross-platform file locks. Original fs2, now supports async and replace libc by rustix."


### PR DESCRIPTION
The old expressions was not compilant with [SPDX 2.3 license expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/), which is required per [cargo docs](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields). This causes the license to fail to parse properly in some tools. 