### PR TITLE
Fix formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Rust
       run: rustup update stable && rustup default stable
     - name: Check formatting
-      run: cargo fmt --all -- --check
+      run: rustfmt --check --edition 2021 $(git ls-files '*.rs')
 
   # This represents the minimum Rust version supported by
   # Bytes. Updating this should be done in a dedicated PR.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,11 @@ async-std = { version = "1", optional = true }
 smol = { version = "2", optional = true }
 tokio = { version = "1", optional = true, default-features = false, features = ["fs"] }
 
-
 [dev-dependencies]
 async-std = { version = "1", features = ["attributes"] }
 smol-potat = "1.1"
 tempdir = "0.3"
-tokio = { version = "1", features = ["full"]}
+tokio = { version = "1", features = ["full"] }
 libc = "0.2"
 
 [package.metadata.docs.rs]

--- a/src/file_ext/async_impl.rs
+++ b/src/file_ext/async_impl.rs
@@ -27,7 +27,7 @@ macro_rules! async_file_ext {
         /// platform-specific behavior. File locks are implemented with
         /// [`flock(2)`](http://man7.org/linux/man-pages/man2/flock.2.html) on Unix and
         /// [`LockFile`](https://msdn.microsoft.com/en-us/library/windows/desktop/aa365202(v=vs.85).aspx)
-        /// on Windows. 
+        /// on Windows.
         pub trait AsyncFileExt {
 
             /// Returns the amount of physical space allocated for a file.
@@ -96,4 +96,3 @@ cfg_smol! {
 cfg_tokio! {
     pub(crate) mod tokio_impl;
 }
-

--- a/src/file_ext/async_impl/smol_impl.rs
+++ b/src/file_ext/async_impl/smol_impl.rs
@@ -1,8 +1,8 @@
-use smol::fs::File;
 #[cfg(unix)]
 use crate::unix::async_impl::smol_impl as sys;
 #[cfg(windows)]
 use crate::windows::async_impl::smol_impl as sys;
+use smol::fs::File;
 
 async_file_ext!(File, "smol::fs::File");
 
@@ -12,26 +12,51 @@ mod test {
     extern crate tempdir;
     extern crate test;
 
+    use crate::{
+        allocation_granularity, available_space, free_space, lock_contended_error,
+        smol::AsyncFileExt, total_space,
+    };
     use smol::fs;
-    use crate::{allocation_granularity, available_space, smol::AsyncFileExt, free_space, lock_contended_error, total_space};
 
     /// Tests shared file lock operations.
     #[smol_potat::test]
     async fn lock_shared() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file3 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file3 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Concurrent shared access is OK, but not shared and exclusive.
         file1.lock_shared().unwrap();
         file2.lock_shared().unwrap();
-        assert_eq!(file3.try_lock_exclusive().unwrap_err().kind(),
-                   lock_contended_error().kind());
+        assert_eq!(
+            file3.try_lock_exclusive().unwrap_err().kind(),
+            lock_contended_error().kind()
+        );
         file1.unlock().unwrap();
-        assert_eq!(file3.try_lock_exclusive().unwrap_err().kind(),
-                   lock_contended_error().kind());
+        assert_eq!(
+            file3.try_lock_exclusive().unwrap_err().kind(),
+            lock_contended_error().kind()
+        );
 
         // Once all shared file locks are dropped, an exclusive lock may be created;
         file2.unlock().unwrap();
@@ -43,15 +68,31 @@ mod test {
     async fn lock_exclusive() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // No other access is possible once an exclusive lock is created.
         file1.lock_exclusive().unwrap();
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().kind(),
-                   lock_contended_error().kind());
-        assert_eq!(file2.try_lock_shared().unwrap_err().kind(),
-                   lock_contended_error().kind());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().kind(),
+            lock_contended_error().kind()
+        );
+        assert_eq!(
+            file2.try_lock_shared().unwrap_err().kind(),
+            lock_contended_error().kind()
+        );
 
         // Once the exclusive lock is dropped, the second file is able to create a lock.
         file1.unlock().unwrap();
@@ -63,12 +104,26 @@ mod test {
     async fn lock_cleanup() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         file1.lock_exclusive().unwrap();
-        assert_eq!(file2.try_lock_shared().unwrap_err().kind(),
-                   lock_contended_error().kind());
+        assert_eq!(
+            file2.try_lock_shared().unwrap_err().kind(),
+            lock_contended_error().kind()
+        );
 
         // Drop file1; the lock should be released.
         drop(file1);
@@ -80,7 +135,12 @@ mod test {
     async fn allocate() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
         let blksize = allocation_granularity(&path).unwrap();
 
         // New files are created with no allocated size.

--- a/src/unix/async_impl/async_std_impl.rs
+++ b/src/unix/async_impl/async_std_impl.rs
@@ -1,6 +1,6 @@
+use async_std::fs::File;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
-use async_std::fs::File;
 
 lock_impl!(File);
 allocate!(File);
@@ -12,7 +12,7 @@ mod test {
 
     use async_std::fs;
 
-    use crate::{lock_contended_error, async_std::AsyncFileExt};
+    use crate::{async_std::AsyncFileExt, lock_contended_error};
 
     /// Tests that locking a file descriptor will replace any existing locks
     /// held on the file descriptor.
@@ -20,8 +20,18 @@ mod test {
     async fn lock_replace() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Creating a shared lock will drop an exclusive lock.
         file1.lock_exclusive().unwrap();
@@ -30,8 +40,10 @@ mod test {
 
         // Attempting to replace a shared lock with an exclusive lock will fail
         // with multiple lock holders, and remove the original shared lock.
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
         file1.lock_shared().unwrap();
     }
 }

--- a/src/unix/async_impl/smol_impl.rs
+++ b/src/unix/async_impl/smol_impl.rs
@@ -1,6 +1,6 @@
+use smol::fs::File;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
-use smol::fs::File;
 
 lock_impl!(File);
 allocate!(File);
@@ -20,8 +20,18 @@ mod test {
     async fn lock_replace() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Creating a shared lock will drop an exclusive lock.
         file1.lock_exclusive().unwrap();
@@ -30,8 +40,10 @@ mod test {
 
         // Attempting to replace a shared lock with an exclusive lock will fail
         // with multiple lock holders, and remove the original shared lock.
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
         file1.lock_shared().unwrap();
     }
 }

--- a/src/unix/async_impl/tokio_impl.rs
+++ b/src/unix/async_impl/tokio_impl.rs
@@ -2,7 +2,6 @@ use std::os::unix::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
 use tokio::fs::File;
 
-
 lock_impl!(File);
 allocate!(File);
 allocate_size!(File);
@@ -21,8 +20,20 @@ mod test {
     async fn lock_replace() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().write(true).create(true).truncate(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().write(true).create(true).truncate(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Creating a shared lock will drop an exclusive lock.
         file1.lock_exclusive().unwrap();
@@ -31,8 +42,10 @@ mod test {
 
         // Attempting to replace a shared lock with an exclusive lock will fail
         // with multiple lock holders, and remove the original shared lock.
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
         file1.lock_shared().unwrap();
     }
 }

--- a/src/windows/async_impl/async_std_impl.rs
+++ b/src/windows/async_impl/async_std_impl.rs
@@ -4,9 +4,9 @@ use std::os::windows::io::AsRawHandle;
 
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::{
-    FileAllocationInfo, FileStandardInfo, GetFileInformationByHandleEx,
-    SetFileInformationByHandle, UnlockFile, FILE_ALLOCATION_INFO,
-    FILE_STANDARD_INFO, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx,
+    FileAllocationInfo, FileStandardInfo, GetFileInformationByHandleEx, LockFileEx,
+    SetFileInformationByHandle, UnlockFile, FILE_ALLOCATION_INFO, FILE_STANDARD_INFO,
+    LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
 };
 
 use async_std::fs::File;
@@ -22,7 +22,7 @@ mod test {
 
     use async_std::fs;
 
-    use crate::{lock_contended_error, async_std::AsyncFileExt}; 
+    use crate::{async_std::AsyncFileExt, lock_contended_error};
 
     /// A file handle may not be exclusively locked multiple times, or exclusively locked and then
     /// shared locked.
@@ -30,18 +30,28 @@ mod test {
     async fn lock_non_reentrant() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Multiple exclusive locks fails.
         file.lock_exclusive().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
         file.unlock().unwrap();
 
         // Shared then Exclusive locks fails.
         file.lock_shared().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
     }
 
     /// A file handle can hold an exclusive lock and any number of shared locks, all of which must
@@ -50,24 +60,36 @@ mod test {
     async fn lock_layering() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.
         file.lock_exclusive().unwrap();
         file.lock_shared().unwrap();
         file.lock_shared().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop one of the shared locks and try again.
         file.unlock().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop the second shared lock and try again.
         file.unlock().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop the exclusive lock and finally succeed.
         file.unlock().unwrap();
@@ -79,13 +101,27 @@ mod test {
     async fn lock_layering_cleanup() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.
         file1.lock_shared().unwrap();
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         drop(file1);
         file2.lock_exclusive().unwrap();

--- a/src/windows/async_impl/smol_impl.rs
+++ b/src/windows/async_impl/smol_impl.rs
@@ -4,9 +4,9 @@ use std::os::windows::io::AsRawHandle;
 
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::{
-    FileAllocationInfo, FileStandardInfo, GetFileInformationByHandleEx,
-    SetFileInformationByHandle, UnlockFile, FILE_ALLOCATION_INFO,
-    FILE_STANDARD_INFO, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx
+    FileAllocationInfo, FileStandardInfo, GetFileInformationByHandleEx, LockFileEx,
+    SetFileInformationByHandle, UnlockFile, FILE_ALLOCATION_INFO, FILE_STANDARD_INFO,
+    LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
 };
 
 use smol::fs::File;
@@ -21,7 +21,7 @@ mod test {
 
     use smol::fs;
 
-    use crate::{lock_contended_error, smol::AsyncFileExt}; 
+    use crate::{lock_contended_error, smol::AsyncFileExt};
 
     /// A file handle may not be exclusively locked multiple times, or exclusively locked and then
     /// shared locked.
@@ -29,18 +29,28 @@ mod test {
     async fn lock_non_reentrant() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Multiple exclusive locks fails.
         file.lock_exclusive().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
         file.unlock().unwrap();
 
         // Shared then Exclusive locks fails.
         file.lock_shared().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
     }
 
     /// A file handle can hold an exclusive lock and any number of shared locks, all of which must
@@ -49,24 +59,36 @@ mod test {
     async fn lock_layering() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.
         file.lock_exclusive().unwrap();
         file.lock_shared().unwrap();
         file.lock_shared().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop one of the shared locks and try again.
         file.unlock().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop the second shared lock and try again.
         file.unlock().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop the exclusive lock and finally succeed.
         file.unlock().unwrap();
@@ -78,13 +100,27 @@ mod test {
     async fn lock_layering_cleanup() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.
         file1.lock_shared().unwrap();
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         drop(file1);
         file2.lock_exclusive().unwrap();

--- a/src/windows/async_impl/tokio_impl.rs
+++ b/src/windows/async_impl/tokio_impl.rs
@@ -4,9 +4,9 @@ use std::os::windows::io::AsRawHandle;
 
 use windows_sys::Win32::Foundation::HANDLE;
 use windows_sys::Win32::Storage::FileSystem::{
-    FileAllocationInfo, FileStandardInfo, GetFileInformationByHandleEx,
-    SetFileInformationByHandle, UnlockFile, FILE_ALLOCATION_INFO,
-    FILE_STANDARD_INFO, LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY, LockFileEx
+    FileAllocationInfo, FileStandardInfo, GetFileInformationByHandleEx, LockFileEx,
+    SetFileInformationByHandle, UnlockFile, FILE_ALLOCATION_INFO, FILE_STANDARD_INFO,
+    LOCKFILE_EXCLUSIVE_LOCK, LOCKFILE_FAIL_IMMEDIATELY,
 };
 
 use tokio::fs::File;
@@ -30,18 +30,28 @@ mod test {
     async fn lock_non_reentrant() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Multiple exclusive locks fails.
         file.lock_exclusive().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
         file.unlock().unwrap();
 
         // Shared then Exclusive locks fails.
         file.lock_shared().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
     }
 
     /// A file handle can hold an exclusive lock and any number of shared locks, all of which must
@@ -50,24 +60,36 @@ mod test {
     async fn lock_layering() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.
         file.lock_exclusive().unwrap();
         file.lock_shared().unwrap();
         file.lock_shared().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop one of the shared locks and try again.
         file.unlock().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop the second shared lock and try again.
         file.unlock().unwrap();
-        assert_eq!(file.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         // Pop the exclusive lock and finally succeed.
         file.unlock().unwrap();
@@ -79,13 +101,27 @@ mod test {
     async fn lock_layering_cleanup() {
         let tempdir = tempdir::TempDir::new("fs4").unwrap();
         let path = tempdir.path().join("fs4");
-        let file1 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
-        let file2 = fs::OpenOptions::new().read(true).write(true).create(true).open(&path).await.unwrap();
+        let file1 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
+        let file2 = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .await
+            .unwrap();
 
         // Open two shared locks on the file, and then try and fail to open an exclusive lock.
         file1.lock_shared().unwrap();
-        assert_eq!(file2.try_lock_exclusive().unwrap_err().raw_os_error(),
-                   lock_contended_error().raw_os_error());
+        assert_eq!(
+            file2.try_lock_exclusive().unwrap_err().raw_os_error(),
+            lock_contended_error().raw_os_error()
+        );
 
         drop(file1);
         file2.lock_exclusive().unwrap();


### PR DESCRIPTION
Like `tokio`, `fs4` uses macros to avoid copy-pasting `#[cfg]` attributes. This prevents `cargo fmt` from seeing modules gated using those macros.
This PR implements the same workaround<sup>[[1]](https://github.com/tokio-rs/tokio/blob/6c42d286b343f498ce29de2aab9358a0aedb081c/.github/workflows/ci.yml#L744)[[2]](https://github.com/tokio-rs/tokio/blob/6c42d286b343f498ce29de2aab9358a0aedb081c/CONTRIBUTING.md#cargo-commands)</sup> as `tokio`, which is to run `rustfmt` directly on all `.rs` files.