### PR TITLE
port tests from tempdir to tempfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-std = { version = "1", features = ["attributes"] }
 fs-err2 = { package = "fs-err", version = "2", features = ["io_safety", "tokio"] }
 fs-err3 = { package = "fs-err", version = "3", features = ["tokio"] }
 smol-potat = "1.1"
-tempdir = "0.3"
+tempfile = "3"
 tokio = { version = "1", features = ["full"] }
 libc = "0.2"
 

--- a/src/file_ext/async_impl.rs
+++ b/src/file_ext/async_impl.rs
@@ -102,7 +102,7 @@ macro_rules! test_mod {
      ($annotation:meta, $($use_stmt:item)*) => {
         #[cfg(test)]
         mod test {
-            extern crate tempdir;
+            extern crate tempfile;
             extern crate test;
             use crate::{
                 allocation_granularity, available_space, free_space,
@@ -116,7 +116,7 @@ macro_rules! test_mod {
             /// Tests shared file lock operations.
             #[$annotation]
             async fn lock_shared() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file1 = fs::OpenOptions::new()
                     .read(true)
@@ -161,7 +161,7 @@ macro_rules! test_mod {
             /// Tests exclusive file lock operations.
             #[$annotation]
             async fn lock_exclusive() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file1 = fs::OpenOptions::new()
                     .read(true)
@@ -197,7 +197,7 @@ macro_rules! test_mod {
             /// Tests that a lock is released after the file that owns it is dropped.
             #[$annotation]
             async fn lock_cleanup() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file1 = fs::OpenOptions::new()
                     .read(true)
@@ -228,7 +228,7 @@ macro_rules! test_mod {
             /// Tests file allocation.
             #[$annotation]
             async fn allocate() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file = fs::OpenOptions::new()
                     .write(true)
@@ -260,7 +260,7 @@ macro_rules! test_mod {
             /// Checks filesystem space methods.
             #[$annotation]
             async fn filesystem_space() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let total_space = total_space(tempdir.path()).unwrap();
                 let free_space = free_space(tempdir.path()).unwrap();
                 let available_space = available_space(tempdir.path()).unwrap();

--- a/src/file_ext/sync_impl.rs
+++ b/src/file_ext/sync_impl.rs
@@ -88,7 +88,7 @@ macro_rules! test_mod {
     ($($use_stmt:item)*) => {
         #[cfg(test)]
         mod test {
-            extern crate tempdir;
+            extern crate tempfile;
             extern crate test;
 
             use super::*;
@@ -104,7 +104,7 @@ macro_rules! test_mod {
             /// Tests shared file lock operations.
             #[test]
             fn lock_shared() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file1 = fs::OpenOptions::new()
                     .read(true)
@@ -149,7 +149,7 @@ macro_rules! test_mod {
             /// Tests exclusive file lock operations.
             #[test]
             fn lock_exclusive() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file1 = fs::OpenOptions::new()
                     .read(true)
@@ -185,7 +185,7 @@ macro_rules! test_mod {
             /// Tests that a lock is released after the file that owns it is dropped.
             #[test]
             fn lock_cleanup() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file1 = fs::OpenOptions::new()
                     .read(true)
@@ -216,7 +216,7 @@ macro_rules! test_mod {
             /// Tests file allocation.
             #[test]
             fn allocate() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file = fs::OpenOptions::new()
                     .write(true)
@@ -248,7 +248,7 @@ macro_rules! test_mod {
             /// Checks filesystem space methods.
             #[test]
             fn filesystem_space() {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let FsStats {
                     free_space,
                     available_space,
@@ -265,7 +265,7 @@ macro_rules! test_mod {
             /// for comparing against the truncate and allocate benchmarks.
             #[bench]
             fn bench_file_create(b: &mut test::Bencher) {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("file");
 
                 b.iter(|| {
@@ -284,7 +284,7 @@ macro_rules! test_mod {
             #[bench]
             fn bench_file_truncate(b: &mut test::Bencher) {
                 let size = 32 * 1024 * 1024;
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("file");
 
                 b.iter(|| {
@@ -304,7 +304,7 @@ macro_rules! test_mod {
             #[bench]
             fn bench_file_allocate(b: &mut test::Bencher) {
                 let size = 32 * 1024 * 1024;
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("file");
 
                 b.iter(|| {
@@ -324,7 +324,7 @@ macro_rules! test_mod {
             #[bench]
             fn bench_allocated_size(b: &mut test::Bencher) {
                 let size = 32 * 1024 * 1024;
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("file");
                 let file = fs::OpenOptions::new()
                     .read(true)
@@ -343,7 +343,7 @@ macro_rules! test_mod {
             /// Benchmarks locking and unlocking a file lock.
             #[bench]
             fn bench_lock_unlock(b: &mut test::Bencher) {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 let path = tempdir.path().join("fs4");
                 let file = fs::OpenOptions::new()
                     .read(true)
@@ -362,7 +362,7 @@ macro_rules! test_mod {
             /// Benchmarks the free space method.
             #[bench]
             fn bench_free_space(b: &mut test::Bencher) {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 b.iter(|| {
                     test::black_box(free_space(tempdir.path()).unwrap());
                 });
@@ -371,7 +371,7 @@ macro_rules! test_mod {
             /// Benchmarks the available space method.
             #[bench]
             fn bench_available_space(b: &mut test::Bencher) {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 b.iter(|| {
                     test::black_box(available_space(tempdir.path()).unwrap());
                 });
@@ -380,7 +380,7 @@ macro_rules! test_mod {
             /// Benchmarks the total space method.
             #[bench]
             fn bench_total_space(b: &mut test::Bencher) {
-                let tempdir = tempdir::TempDir::new("fs4").unwrap();
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
                 b.iter(|| {
                     test::black_box(total_space(tempdir.path()).unwrap());
                 });

--- a/src/unix/async_impl.rs
+++ b/src/unix/async_impl.rs
@@ -58,7 +58,7 @@ macro_rules! test_mod {
     ($annotation:meta, $($use_stmt:item)*) => {
         #[cfg(test)]
         mod test {
-          extern crate tempdir;
+          extern crate tempfile;
 
           use crate::lock_contended_error;
 
@@ -70,7 +70,7 @@ macro_rules! test_mod {
           /// held on the file descriptor.
           #[$annotation]
           async fn lock_replace() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+            let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file1 = fs::OpenOptions::new()
                   .write(true)

--- a/src/unix/sync_impl.rs
+++ b/src/unix/sync_impl.rs
@@ -58,7 +58,7 @@ macro_rules! test_mod {
     ($($use_stmt:item)*) => {
         #[cfg(test)]
         mod test {
-          extern crate tempdir;
+          extern crate tempfile;
 
           use crate::lock_contended_error;
 
@@ -70,7 +70,7 @@ macro_rules! test_mod {
           /// held on the file descriptor.
           #[test]
           fn lock_replace() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+            let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file1 = fs::OpenOptions::new()
                   .write(true)

--- a/src/windows/async_impl.rs
+++ b/src/windows/async_impl.rs
@@ -52,7 +52,7 @@ macro_rules! test_mod {
     ($annotation:meta, $($use_stmt:item)*) => {
         #[cfg(test)]
         mod test {
-          extern crate tempdir;
+          extern crate tempfile;
 
           use crate::lock_contended_error;
 
@@ -64,7 +64,7 @@ macro_rules! test_mod {
           /// shared locked.
           #[$annotation]
           async fn lock_non_reentrant() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+              let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file = fs::OpenOptions::new()
                   .read(true)
@@ -94,7 +94,7 @@ macro_rules! test_mod {
           /// be unlocked independently.
           #[$annotation]
           async fn lock_layering() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+              let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file = fs::OpenOptions::new()
                   .read(true)
@@ -135,7 +135,7 @@ macro_rules! test_mod {
           /// A file handle with multiple open locks will have all locks closed on drop.
           #[$annotation]
           async fn lock_layering_cleanup() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+              let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file1 = fs::OpenOptions::new()
                   .read(true)

--- a/src/windows/sync_impl.rs
+++ b/src/windows/sync_impl.rs
@@ -52,7 +52,7 @@ macro_rules! test_mod {
     ($($use_stmt:item)*) => {
         #[cfg(test)]
         mod test {
-          extern crate tempdir;
+          extern crate tempfile;
 
           use crate::lock_contended_error;
 
@@ -64,7 +64,7 @@ macro_rules! test_mod {
           /// shared locked.
           #[test]
           fn lock_non_reentrant() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+              let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file = fs::OpenOptions::new()
                   .read(true)
@@ -93,7 +93,7 @@ macro_rules! test_mod {
           /// be unlocked independently.
           #[test]
           fn lock_layering() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+              let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file = fs::OpenOptions::new()
                   .read(true)
@@ -133,7 +133,7 @@ macro_rules! test_mod {
           /// A file handle with multiple open locks will have all locks closed on drop.
           #[test]
           fn lock_layering_cleanup() {
-              let tempdir = tempdir::TempDir::new("fs4").unwrap();
+              let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
               let path = tempdir.path().join("fs4");
               let file1 = fs::OpenOptions::new()
                   .read(true)


### PR DESCRIPTION
The tempdir crate is unmaintained, was last updated seven years ago, and pulls in really old versions of some of its dependencies.

The tempfile crate is actively maintained and replacing code usages is straightforward.
