### PR TITLE
Add redox support

### DIFF
--- a/src/unix/sync_impl.rs
+++ b/src/unix/sync_impl.rs
@@ -38,6 +38,7 @@ macro_rules! allocate {
             target_os = "openbsd",
             target_os = "netbsd",
             target_os = "dragonfly",
+            target_os = "redox",
             target_os = "solaris",
             target_os = "illumos",
             target_os = "haiku",


### PR DESCRIPTION
Make this crate compiling with [Redox OS](https://doc.rust-lang.org/nightly/rustc/platform-support/redox.html) by commenting out `fallocate` (it's not supported by the OS at this time).

The other one is already pushed to rustix https://github.com/bytecodealliance/rustix/pull/1506.
