### PR TITLE
Fix Rust 1.89+ compatibility.

### DIFF
--- a/src/file_ext/sync_impl.rs
+++ b/src/file_ext/sync_impl.rs
@@ -177,7 +177,7 @@ macro_rules! test_mod {
                     false,
                 );
                 assert_eq!(
-                    file2.try_lock_shared().unwrap(),
+                    FileExt::try_lock_shared(&file2).unwrap(),
                     false,
                 );
 
@@ -208,7 +208,7 @@ macro_rules! test_mod {
 
                 file1.lock_exclusive().unwrap();
                 assert_eq!(
-                    file2.try_lock_shared().unwrap(),
+                    FileExt::try_lock_shared(&file2).unwrap(),
                     false,
                 );
 


### PR DESCRIPTION
Rust 1.89 introduced a `try_lock_shared` method with different signature.

This PR makes the tests pick up the right `try_lock_shared`.

CC @al8n 