### PR TITLE
Update windows-sys to >= 0.59, <= 0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ fs-err3-tokio = ["fs-err3", "fs-err3/tokio"]
 rustix = { version = "1", features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.59"
+version = ">= 0.59, <= 0.61"
 features = ["Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO"]
 
 [dependencies]


### PR DESCRIPTION
`windows-sys` 0.61.x is very important for me, because it consistently uses `raw-dylib` for importing APIs from Windows DLLs. This makes a huge difference when using non-MSVC toolchains to build Windows binaries, e.g. `x86_64-pc-windows-gnullvm`.

This syntax is recommended by Microsoft in https://crates.io/crates/windows-sys/0.61.2.
It helps to eradicate duplicate `windows-sys` dependencies from the dependency tree of a complex project.

CC @al8n 