### PR TITLE
Release v1.0.1: fix sparse allocate, Windows statvfs, Fuchsia build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Releases
 
+## 1.0.1
+
+### Fixes
+
+- Unix `allocate`: short-circuit on allocated blocks
+  (`metadata().blocks() * 512 >= len`) instead of logical EOF. The
+  previous `metadata().len() >= len` check silently turned `allocate`
+  into a no-op on sparse files (logical length large, zero blocks
+  reserved), violating the documented preallocation guarantee. The
+  new check still skips the macOS `F_PREALLOCATE` re-allocate-ENOSPC
+  path from #15, since it asks the right question: "are the blocks
+  already reserved?" Applies to both the sync and async
+  implementations.
+- Windows `statvfs`: route the three `GetDiskFreeSpaceExW` outputs
+  correctly. `free_space` now comes from `lpTotalNumberOfFreeBytes`
+  (volume-wide, quota-independent), `available_space` from
+  `lpFreeBytesAvailable` (caller-scoped, honours per-user quotas),
+  and `total_space` is computed from cluster math
+  (`sectors_per_cluster * bytes_per_sector * total_number_of_clusters`)
+  so it reports volume capacity rather than the caller's quota. On
+  quota-enabled volumes the three fields now carry distinct,
+  documented meanings; previously `free_space` and `available_space`
+  were identical and `total_space` under-reported capacity.
+- Added `target_os = "fuchsia"` to the Unix `allocate` `fallocate`
+  branch (sync and async). Fuchsia is `cfg(unix)` under rustc and
+  `rustix` exposes `fallocate` there, so the previous omission left
+  the Fuchsia Unix build without an `allocate` symbol once `FileExt`
+  was enabled.
+
+### Testing
+
+- New regression test `allocate_reserves_blocks_on_sparse_file`
+  (sync and async, Linux-gated) creates a sparse file via `set_len`,
+  asserts `allocated_size == 0`, calls `allocate`, and asserts
+  blocks are reserved.
+
+### Documentation
+
+- README gained a **Minimum Supported Rust Version** section noting
+  that the crate's declared MSRV (`rust-version = "1.75.0"`) covers
+  the default `sync` feature, and that `async-std` / `smol` inherit
+  a higher effective MSRV (1.85) from their transitive dependencies
+  (`async-lock`, `async-signal`).
+
 ## 1.0.0
 
 ### Breakage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,12 @@
   branch (sync and async). Fuchsia is `cfg(unix)` under rustc and
   `rustix` exposes `fallocate` there, so the previous omission left
   the Fuchsia Unix build without an `allocate` symbol once `FileExt`
-  was enabled.
+  was enabled. With this fix, every fs4 feature builds on Fuchsia
+  **except** `fs-err3` and `fs-err3-tokio`; those remain blocked on
+  `fs-err v3.3.0` referencing `std::os::unix::fs::chroot`, which
+  rustc gates out on `target_os = "fuchsia"`. The fs4 code no longer
+  has a Fuchsia gap — the remaining one is upstream
+  (<https://github.com/andrewhickman/fs-err/issues/90>).
 
 ### Testing
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fs4"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.0.0"
+version = "1.0.1"
 rust-version = "1.75.0"
 authors = ["Dan Burkert <dan@danburkert.com>", "Al Liu <scygliu1@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -89,6 +89,23 @@ and replace `libc` by [rustix](https://github.com/bytecodealliance/rustix).
 - [x] [smol support](https://crates.io/crates/smol)
 - [x] [tokio support](https://crates.io/crates/tokio)
 
+## Minimum Supported Rust Version
+
+`fs4` itself compiles on Rust **1.75.0** (the value of `rust-version` in
+`Cargo.toml`), and that guarantee covers the default `sync` feature.
+
+Some opt-in features inherit a higher MSRV from their transitive
+dependencies — enabling them requires whatever toolchain those crates
+ask for, not what `fs4` declares:
+
+| Feature                                     | Effective MSRV | Reason                                                         |
+| ------------------------------------------- | -------------- | -------------------------------------------------------------- |
+| `async-std`                                 | 1.85           | `async-std` pulls `async-lock >= 3.4.2` (`rust-version = 1.85`) |
+| `smol`                                      | 1.85           | `smol` pulls `async-signal >= 0.2.14` (`rust-version = 1.85`)   |
+
+These bounds are set by upstream and can drift with future minor
+releases; pin the relevant dependency if you need an older toolchain.
+
 ## License
 
 `fs4` is primarily distributed under the terms of both the MIT license and the

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ ask for, not what `fs4` declares:
 These bounds are set by upstream and can drift with future minor
 releases; pin the relevant dependency if you need an older toolchain.
 
+## Platform Notes
+
+### Fuchsia
+
+Every feature builds on Fuchsia **except** `fs-err3` and
+`fs-err3-tokio`. The blocker is upstream: `fs-err v3.3.0` calls
+`std::os::unix::fs::chroot`, which rustc gates out on
+`target_os = "fuchsia"`. The fs4 Unix modules themselves compile
+on Fuchsia (`sync`, `fs-err2`, `async-std`, `smol`, `tokio` all
+work). Tracking issue: <https://github.com/andrewhickman/fs-err/issues/90>.
+
 ## License
 
 `fs4` is primarily distributed under the terms of both the MIT license and the

--- a/src/file_ext/async_impl.rs
+++ b/src/file_ext/async_impl.rs
@@ -297,6 +297,40 @@ macro_rules! test_mod {
                 assert!(file.metadata().await.unwrap().len() >= 2 * blksize - 1);
             }
 
+            /// Regression: `allocate` on a sparse file must reserve
+            /// blocks even when logical EOF already covers `len`. The
+            /// previous Unix implementation short-circuited on
+            /// `metadata().len()`, which for a file extended via
+            /// `set_len` is true with zero blocks allocated, so the
+            /// documented preallocation contract silently became a
+            /// no-op. Gated to Linux where `set_len` reliably
+            /// produces a sparse file and `st_blocks` reliably
+            /// reflects `fallocate` reservations.
+            #[cfg(target_os = "linux")]
+            #[$annotation]
+            async fn allocate_reserves_blocks_on_sparse_file() {
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
+                let path = tempdir.path().join("fs4");
+                let file = fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .open(&path)
+                    .await
+                    .unwrap();
+                let blksize = allocation_granularity(&path).unwrap();
+
+                file.set_len(4 * blksize).await.unwrap();
+                assert_eq!(4 * blksize, file.metadata().await.unwrap().len());
+                assert_eq!(0, file.allocated_size().await.unwrap());
+
+                file.allocate(4 * blksize).await.unwrap();
+
+                assert!(
+                    file.allocated_size().await.unwrap() >= 4 * blksize,
+                    "allocate on a sparse file must reserve blocks",
+                );
+            }
+
             /// Regression test for issue #15: re-allocating the same length must
             /// not fail on macOS.
             #[$annotation]

--- a/src/file_ext/sync_impl.rs
+++ b/src/file_ext/sync_impl.rs
@@ -299,6 +299,43 @@ macro_rules! test_mod {
                 assert!(file.metadata().unwrap().len() >= 2 * blksize - 1);
             }
 
+            /// Regression: `allocate` on a sparse file must reserve
+            /// blocks even when logical EOF already covers `len`. The
+            /// previous Unix implementation short-circuited on
+            /// `metadata().len()`, which for a file extended via
+            /// `set_len` is true with zero blocks allocated, so the
+            /// documented preallocation contract silently became a
+            /// no-op. Gated to Linux where `set_len` reliably
+            /// produces a sparse file and `st_blocks` reliably
+            /// reflects `fallocate` reservations.
+            #[cfg(target_os = "linux")]
+            #[test]
+            fn allocate_reserves_blocks_on_sparse_file() {
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
+                let path = tempdir.path().join("fs4");
+                let file = fs::OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&path)
+                    .unwrap();
+                let blksize = allocation_granularity(&path).unwrap();
+
+                // `set_len` extends logical EOF without reserving blocks:
+                // the file is sparse with `len = 4 * blksize` and
+                // `allocated_size = 0`.
+                file.set_len(4 * blksize).unwrap();
+                assert_eq!(4 * blksize, file.metadata().unwrap().len());
+                assert_eq!(0, FileExt::allocated_size(&file).unwrap());
+
+                FileExt::allocate(&file, 4 * blksize).unwrap();
+
+                assert!(
+                    FileExt::allocated_size(&file).unwrap() >= 4 * blksize,
+                    "allocate on a sparse file must reserve blocks",
+                );
+            }
+
             /// Re-allocating the same length must not fail. Regression for issue #15.
             #[test]
             fn allocate_idempotent() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //! Extended utilities for working with files and filesystems in Rust.
-#![doc(html_root_url = "https://docs.rs/fs4/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/fs4/1.0.1")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, allow(unused_attributes))]
 #![allow(unexpected_cfgs, unstable_name_collisions)]

--- a/src/unix/async_impl.rs
+++ b/src/unix/async_impl.rs
@@ -3,6 +3,7 @@ macro_rules! allocate {
     #[cfg(any(
       target_os = "linux",
       target_os = "freebsd",
+      target_os = "fuchsia",
       target_os = "android",
       target_os = "emscripten",
       target_os = "nacl",
@@ -16,10 +17,11 @@ macro_rules! allocate {
         fd::BorrowedFd,
         fs::{fallocate, FallocateFlags},
       };
-      // See the comment in the sync implementation. Short-circuit when
-      // the file is already large enough to avoid the macOS
-      // `F_PREALLOCATE` re-allocate-ENOSPC issue (#15).
-      if file.metadata().await?.len() >= len {
+      // See the comment in the sync implementation: short-circuit on
+      // allocated blocks (not logical EOF) so sparse files still hit
+      // fallocate while already-preallocated files skip the macOS
+      // `F_PREALLOCATE` re-allocate-ENOSPC path (#15).
+      if file.metadata().await?.blocks().saturating_mul(512) >= len {
         return Ok(());
       }
       unsafe {

--- a/src/unix/sync_impl.rs
+++ b/src/unix/sync_impl.rs
@@ -11,6 +11,7 @@ macro_rules! allocate {
     #[cfg(any(
       target_os = "linux",
       target_os = "freebsd",
+      target_os = "fuchsia",
       target_os = "android",
       target_os = "emscripten",
       target_os = "nacl",
@@ -24,10 +25,12 @@ macro_rules! allocate {
         fd::BorrowedFd,
         fs::{fallocate, FallocateFlags},
       };
-      // See the comment in file_ext/sync_impl.rs. Short-circuit when the
-      // file is already large enough to avoid the macOS
-      // `F_PREALLOCATE` re-allocate-ENOSPC issue (#15).
-      if file.metadata()?.len() >= len {
+      // Short-circuit when blocks are already reserved to at least `len`.
+      // Using allocated size (not logical EOF) avoids the macOS
+      // `F_PREALLOCATE` re-allocate-ENOSPC issue (#15) without falsely
+      // skipping sparse files whose logical length exceeds their
+      // allocation.
+      if file.metadata()?.blocks().saturating_mul(512) >= len {
         return Ok(());
       }
       unsafe {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -118,13 +118,19 @@ pub fn statvfs(path: &Path) -> Result<FsStats> {
   let root_path: &mut [u16] = &mut [0; 261];
   volume_path(path, root_path)?;
   unsafe {
-    let mut free_space = 0;
-    let mut total_space = 0;
+    // `GetDiskFreeSpaceExW` returns three distinct numbers we must not
+    // conflate on quota-enabled volumes: caller-scoped free (honours
+    // per-user quotas) → `available_space`; caller-scoped total
+    // (unused here, see `total_space` below); and volume-wide free
+    // (quota-independent) → `free_space`.
+    let mut bytes_available_to_caller = 0u64;
+    let mut _caller_total_bytes = 0u64;
+    let mut free_bytes_on_volume = 0u64;
     let ret = GetDiskFreeSpaceExW(
       root_path.as_ptr(),
-      &mut free_space,
-      &mut total_space,
-      std::ptr::null_mut(),
+      &mut bytes_available_to_caller,
+      &mut _caller_total_bytes,
+      &mut free_bytes_on_volume,
     );
     if ret == 0 {
       return Err(Error::last_os_error());
@@ -133,21 +139,22 @@ pub fn statvfs(path: &Path) -> Result<FsStats> {
     let mut sectors_per_cluster = 0;
     let mut bytes_per_sector = 0;
     let mut _number_of_free_clusters = 0;
-    let mut _total_number_of_clusters = 0;
+    let mut total_number_of_clusters = 0;
     let ret = GetDiskFreeSpaceW(
       root_path.as_ptr(),
       &mut sectors_per_cluster,
       &mut bytes_per_sector,
       &mut _number_of_free_clusters,
-      &mut _total_number_of_clusters,
+      &mut total_number_of_clusters,
     );
     if ret == 0 {
       Err(Error::last_os_error())
     } else {
       let bytes_per_cluster = sectors_per_cluster as u64 * bytes_per_sector as u64;
+      let total_space = bytes_per_cluster.saturating_mul(total_number_of_clusters as u64);
       Ok(FsStats {
-        free_space,
-        available_space: free_space,
+        free_space: free_bytes_on_volume,
+        available_space: bytes_available_to_caller,
         total_space,
         allocation_granularity: bytes_per_cluster,
       })


### PR DESCRIPTION
## Summary

Patch release against v1.0.0. No public API changes; four bug fixes plus docs.

- **Sparse-file `allocate` (Unix, sync + async)** — the short-circuit on `metadata().len() >= len` silently turned `allocate` into a no-op on sparse files (logical length large, zero blocks reserved). Now gated on `metadata().blocks() * 512 >= len`, which asks the right question ("are the blocks already reserved?") and still skips the macOS `F_PREALLOCATE` re-allocate-ENOSPC path from #15.
- **Windows `statvfs`** — `GetDiskFreeSpaceExW` returns three distinct numbers. The previous code passed NULL for the third pointer, reused `lpFreeBytesAvailable` as both `free_space` and `available_space`, and let `total_space` come from the caller-scoped quota total. Now routes `lpTotalNumberOfFreeBytes` → `free_space` (volume-wide, quota-independent), `lpFreeBytesAvailable` → `available_space` (caller quota), and computes `total_space` from cluster math (`sectors_per_cluster * bytes_per_sector * total_number_of_clusters`) so it reports volume capacity. Visibly changes values on quota-enabled volumes.
- **Fuchsia build** — `target_os = "fuchsia"` added to the Unix fallocate branch (sync + async). Fuchsia is `cfg(unix)` under rustc and `rustix` exposes `fallocate` there, so the previous omission left Fuchsia builds without an `allocate` symbol once `FileExt` was enabled. With this fix, every fs4 feature builds on Fuchsia **except** `fs-err3` / `fs-err3-tokio`; those remain blocked on upstream `fs-err v3` referencing `std::os::unix::fs::chroot`, which rustc gates out on Fuchsia. Tracking: https://github.com/andrewhickman/fs-err/issues/90.
- **Docs** — README gains a **Minimum Supported Rust Version** section (the declared `rust-version = "1.75.0"` covers the default `sync` feature; `async-std` / `smol` effectively require 1.85 via transitive `async-lock` / `async-signal`) and a **Platform Notes → Fuchsia** subsection documenting the upstream `fs-err` gap.

### Testing

New Linux-gated regression test `allocate_reserves_blocks_on_sparse_file` (sync + async): creates a sparse file via `set_len`, asserts `allocated_size == 0`, calls `allocate`, asserts blocks are reserved.

### Semver

Patch. No public API added, removed, or altered. The Windows `statvfs` fix changes observable numeric values on quota-enabled volumes, but the previous values were documented-incorrect.

## Test plan

- [ ] `cargo test --all-features` on ubuntu, macos, windows via CI
- [ ] `cargo hack clippy --each-feature` green on all CI OSes
- [ ] Cross-compile sanity for `x86_64-unknown-fuchsia` once CI is extended (new target worth adding)
- [ ] Manual: verify new `free_space` / `total_space` values on a Windows volume with a user quota configured