### PR TITLE
Release v1.1.0: unify backend traits, seal them, add DynAsyncFileExt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Releases
 
+## 1.1.0
+
+### Changes
+
+- Consolidate `FileExt` and `AsyncFileExt` into single crate-root traits
+  (`fs4::FileExt`, `fs4::AsyncFileExt`) instead of generating a distinct
+  trait per backend module. The per-backend modules (`fs4::tokio`,
+  `fs4::async_std`, `fs4::smol`, `fs4::fs_err2`, `fs4::fs_err3`,
+  `fs4::fs_err2_tokio`, `fs4::fs_err3_tokio`) now re-export the unified
+  crate-root trait. Method-call sites that import the trait via `use`
+  continue to compile unchanged; code that named two backend traits as
+  distinct types will see them unify.
+- Add blanket impls `impl<F: FileExt + ?Sized> FileExt for &F` and
+  `impl<F: AsyncFileExt + ?Sized> AsyncFileExt for &F`, so the
+  extension methods are now callable through shared references.
+- Seal `FileExt` and `AsyncFileExt` via a private `sealed::Sealed`
+  supertrait, so the set of implementing types is closed to the
+  concrete file types fs4 already supports (and references to them).
+  This locks in the freedom to add methods to either trait in future
+  minor releases without breaking downstream impls.
+- Add `DynAsyncFileExt`, an object-safe mirror of `AsyncFileExt` whose
+  async methods return `BoxFuture<'_, T>` (alias for
+  `Pin<Box<dyn Future<Output = T> + Send + '_>>`). Use it whenever
+  type erasure is needed (`Box<dyn DynAsyncFileExt>`,
+  `&dyn DynAsyncFileExt`); prefer the static `AsyncFileExt` for
+  generic code since it has no allocation or dynamic-dispatch
+  overhead. Every type implementing `AsyncFileExt` also implements
+  `DynAsyncFileExt`, and the trait is sealed.
+- Mark the delegating methods `#[inline(always)]` (skipped under
+  `tarpaulin` coverage builds).
+
 ## 1.0.1
 
 ### Fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fs4"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.0.2"
+version = "1.0.3"
 rust-version = "1.75.0"
 authors = ["Dan Burkert <dan@danburkert.com>", "Al Liu <scygliu1@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fs4"
 # NB: When modifying, also modify html_root_url in lib.rs
-version = "1.0.3"
+version = "1.1.0"
 rust-version = "1.75.0"
 authors = ["Dan Burkert <dan@danburkert.com>", "Al Liu <scygliu1@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ fs-err3 = { package = "fs-err", version = "3", features = ["tokio"] }
 smol-potat = "1.1"
 tempfile = "3"
 tokio = { version = "1", features = ["full"] }
-libc = "0.2"
+
 
 [package.metadata.docs.rs]
 all-features = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -3,6 +3,7 @@ hard_tabs = false
 tab_spaces = 2
 newline_style = "Auto"
 use_small_heuristics = "Default"
+imports_granularity = "Crate"
 reorder_imports = true
 reorder_modules = true
 remove_nested_parens = true

--- a/src/file_ext/async_impl.rs
+++ b/src/file_ext/async_impl.rs
@@ -92,6 +92,77 @@ macro_rules! test_mod {
                 $use_stmt
             )*
 
+            /// Exercises `impl<F: AsyncFileExt + ?Sized> AsyncFileExt for &F`.
+            /// The other tests call methods directly on the concrete file type
+            /// and resolve to `<File as AsyncFileExt>::*`, so without this the
+            /// blanket-impl bodies are unreached.
+            #[$annotation]
+            async fn async_file_ext_blanket_for_ref() {
+                async fn drive<F: AsyncFileExt + ?Sized>(f: &F, len: u64) {
+                    f.lock_shared().unwrap();
+                    f.unlock().unwrap();
+                    f.lock().unwrap();
+                    f.unlock().unwrap();
+                    f.try_lock_shared().unwrap();
+                    f.unlock().unwrap();
+                    f.try_lock().unwrap();
+                    f.unlock_async().await.unwrap();
+                    f.allocate(len).await.unwrap();
+                    let _ = f.allocated_size().await.unwrap();
+                }
+
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
+                let path = tempdir.path().join("fs4");
+                let file = fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .open(&path)
+                    .await
+                    .unwrap();
+                let blksize = allocation_granularity(&path).unwrap();
+
+                // `&&file` binds `F = &File`, so calls go through the blanket.
+                drive(&&file, blksize).await;
+            }
+
+            /// Drives every `DynAsyncFileExt` method twice: once on the
+            /// concrete file type to cover the per-backend macro impl, and
+            /// once through `&File` to cover the `for &F` blanket.
+            #[$annotation]
+            async fn dyn_async_file_ext_smoke() {
+                use crate::DynAsyncFileExt;
+
+                async fn drive<F: DynAsyncFileExt + ?Sized>(f: &F, len: u64) {
+                    f.lock_shared().unwrap();
+                    f.unlock().unwrap();
+                    f.lock().unwrap();
+                    f.unlock().unwrap();
+                    f.try_lock_shared().unwrap();
+                    f.unlock().unwrap();
+                    f.try_lock().unwrap();
+                    f.unlock_async().await.unwrap();
+                    f.allocate(len).await.unwrap();
+                    let _ = f.allocated_size().await.unwrap();
+                }
+
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
+                let path = tempdir.path().join("fs4");
+                let file = fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .open(&path)
+                    .await
+                    .unwrap();
+                let blksize = allocation_granularity(&path).unwrap();
+
+                // `&file` binds `F = File`, exercising the per-backend impl.
+                drive(&file, blksize).await;
+                // `&&file` binds `F = &File`, exercising the blanket impl.
+                drive(&&file, blksize).await;
+            }
+
             /// Tests shared file lock operations.
             #[$annotation]
             async fn lock_shared() {

--- a/src/file_ext/async_impl.rs
+++ b/src/file_ext/async_impl.rs
@@ -2,6 +2,8 @@ macro_rules! async_file_ext {
     ($file: ty, $file_name: literal) => {
         use std::io::Result;
 
+        impl $crate::sealed::Sealed for $file {}
+
         impl $crate::AsyncFileExt for $file {
             async fn allocated_size(&self) -> Result<u64> {
                 sys::allocated_size(self).await
@@ -31,6 +33,48 @@ macro_rules! async_file_ext {
 
             async fn unlock_async(&self) -> Result<()> {
                 sys::unlock(self)
+            }
+        }
+
+        impl $crate::DynAsyncFileExt for $file {
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn allocated_size(&self) -> $crate::BoxFuture<'_, Result<u64>> {
+                Box::pin(<Self as $crate::AsyncFileExt>::allocated_size(self))
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn allocate(&self, len: u64) -> $crate::BoxFuture<'_, Result<()>> {
+                Box::pin(<Self as $crate::AsyncFileExt>::allocate(self, len))
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn lock_shared(&self) -> Result<()> {
+                <Self as $crate::AsyncFileExt>::lock_shared(self)
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn lock(&self) -> Result<()> {
+                <Self as $crate::AsyncFileExt>::lock(self)
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn try_lock_shared(&self) -> std::result::Result<(), $crate::TryLockError> {
+                <Self as $crate::AsyncFileExt>::try_lock_shared(self)
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn try_lock(&self) -> std::result::Result<(), $crate::TryLockError> {
+                <Self as $crate::AsyncFileExt>::try_lock(self)
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn unlock(&self) -> Result<()> {
+                <Self as $crate::AsyncFileExt>::unlock(self)
+            }
+
+            #[cfg_attr(not(tarpaulin), inline(always))]
+            fn unlock_async(&self) -> $crate::BoxFuture<'_, Result<()>> {
+                Box::pin(<Self as $crate::AsyncFileExt>::unlock_async(self))
             }
         }
     }

--- a/src/file_ext/async_impl.rs
+++ b/src/file_ext/async_impl.rs
@@ -2,88 +2,7 @@ macro_rules! async_file_ext {
     ($file: ty, $file_name: literal) => {
         use std::io::Result;
 
-        #[doc = concat!("Extension trait for `", $file_name, "` which provides allocation and locking methods.")]
-        ///
-        /// ## Notes on File Locks
-        ///
-        /// This library provides whole-file locks in both shared (read) and exclusive
-        /// (read-write) varieties.
-        ///
-        /// File locks are a cross-platform hazard since the file lock APIs exposed by
-        /// operating system kernels vary in subtle and not-so-subtle ways.
-        ///
-        /// The API exposed by this library can be safely used across platforms as long
-        /// as the following rules are followed:
-        ///
-        ///   * Multiple locks should not be created on an individual `File` instance
-        ///     concurrently.
-        ///   * Duplicated files should not be locked without great care.
-        ///   * Files to be locked should be opened with at least read or write
-        ///     permissions.
-        ///   * File locks may only be relied upon to be advisory.
-        ///
-        /// File locks are released automatically when the file handle is closed (for
-        /// example when the owning `File` is dropped), so calling [`AsyncFileExt::unlock`]
-        /// explicitly is optional.
-        ///
-        /// File locks are implemented with
-        /// [`flock(2)`](http://man7.org/linux/man-pages/man2/flock.2.html) on Unix and
-        /// [`LockFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex)
-        /// on Windows. The `lock_*` and `try_lock_*` methods are synchronous because
-        /// the underlying system calls are blocking. The separate
-        /// [`AsyncFileExt::unlock_async`] method is provided for convenience inside
-        /// async code, but the underlying `unlock` syscall is still blocking.
-        pub trait AsyncFileExt {
-            /// Returns the amount of physical space allocated for a file.
-            fn allocated_size(&self) -> impl core::future::Future<Output = Result<u64>>;
-
-            /// Ensures that at least `len` bytes of disk space are allocated for the
-            /// file. After a successful call to `allocate`, subsequent writes to the
-            /// file within the specified length are guaranteed not to fail because of
-            /// lack of disk space.
-            ///
-            /// On most platforms the file's logical size is also extended to `len`
-            /// bytes. On Windows, if the file's existing cluster-aligned allocation
-            /// already covers `len`, the logical size is left unchanged to work around
-            /// buffered-I/O quirks observed when the end-of-file pointer is moved
-            /// inside an already-allocated cluster.
-            fn allocate(&self, len: u64) -> impl core::future::Future<Output = Result<()>>;
-
-            /// Acquires a shared lock on the file, blocking until the lock can be
-            /// acquired.
-            fn lock_shared(&self) -> Result<()>;
-
-            /// Acquires an exclusive lock on the file, blocking until the lock can be
-            /// acquired. Mirrors [`std::fs::File::lock`].
-            fn lock(&self) -> Result<()>;
-
-            /// Attempts to acquire a shared lock on the file, without blocking.
-            ///
-            /// Returns `Ok(())` if the lock was acquired, or
-            /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
-            /// if the file is currently locked.
-            fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError>;
-
-            /// Attempts to acquire an exclusive lock on the file, without blocking.
-            ///
-            /// Returns `Ok(())` if the lock was acquired, or
-            /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
-            /// if the file is currently locked.
-            fn try_lock(&self) -> std::result::Result<(), crate::TryLockError>;
-
-            /// Releases any lock held on the file. The lock is also released
-            /// automatically when the file handle is closed.
-            fn unlock(&self) -> Result<()>;
-
-            /// Releases any lock held on the file.
-            ///
-            /// **Note:** This method is not truly async; the underlying system call is
-            /// still blocking. It exists for convenience when used from an async
-            /// context.
-            fn unlock_async(&self) -> impl core::future::Future<Output = Result<()>>;
-        }
-
-        impl AsyncFileExt for $file {
+        impl $crate::AsyncFileExt for $file {
             async fn allocated_size(&self) -> Result<u64> {
                 sys::allocated_size(self).await
             }
@@ -98,11 +17,11 @@ macro_rules! async_file_ext {
                 sys::lock(self)
             }
 
-            fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError> {
+            fn try_lock_shared(&self) -> std::result::Result<(), $crate::TryLockError> {
                 sys::try_lock_shared(self)
             }
 
-            fn try_lock(&self) -> std::result::Result<(), crate::TryLockError> {
+            fn try_lock(&self) -> std::result::Result<(), $crate::TryLockError> {
                 sys::try_lock(self)
             }
 
@@ -122,7 +41,8 @@ macro_rules! test_mod {
         #[cfg(test)]
         mod test {
             extern crate tempfile;
-            use crate::{allocation_granularity, TryLockError};
+
+            use crate::{allocation_granularity, TryLockError, AsyncFileExt};
 
             $(
                 $use_stmt

--- a/src/file_ext/async_impl/async_std_impl.rs
+++ b/src/file_ext/async_impl/async_std_impl.rs
@@ -8,6 +8,5 @@ async_file_ext!(File, "async_std::fs::File");
 
 test_mod! {
   async_std::test,
-  use crate::async_std::AsyncFileExt;
   use async_std::fs;
 }

--- a/src/file_ext/async_impl/fs_err2_tokio_impl.rs
+++ b/src/file_ext/async_impl/fs_err2_tokio_impl.rs
@@ -8,6 +8,5 @@ async_file_ext!(File, "fs_err::tokio::File");
 
 test_mod! {
   tokio::test,
-  use crate::fs_err2_tokio::AsyncFileExt;
   use fs_err2::tokio as fs;
 }

--- a/src/file_ext/async_impl/fs_err3_tokio_impl.rs
+++ b/src/file_ext/async_impl/fs_err3_tokio_impl.rs
@@ -8,6 +8,5 @@ async_file_ext!(File, "fs_err::tokio::File");
 
 test_mod! {
   tokio::test,
-  use crate::fs_err3_tokio::AsyncFileExt;
   use fs_err3::tokio as fs;
 }

--- a/src/file_ext/async_impl/smol_impl.rs
+++ b/src/file_ext/async_impl/smol_impl.rs
@@ -8,6 +8,5 @@ async_file_ext!(File, "smol::fs::File");
 
 test_mod! {
   smol_potat::test,
-  use crate::smol::AsyncFileExt;
   use smol::fs;
 }

--- a/src/file_ext/async_impl/tokio_impl.rs
+++ b/src/file_ext/async_impl/tokio_impl.rs
@@ -8,6 +8,5 @@ async_file_ext!(File, "tokio::fs::File");
 
 test_mod! {
   tokio::test,
-  use crate::tokio::AsyncFileExt;
   use tokio::fs;
 }

--- a/src/file_ext/sync_impl.rs
+++ b/src/file_ext/sync_impl.rs
@@ -49,6 +49,41 @@ macro_rules! test_mod {
                 $use_stmt
             )*
 
+            /// Exercises `impl<F: FileExt + ?Sized> FileExt for &F`. Without this
+            /// every method body in the blanket impl is uncovered, since the
+            /// other tests call methods directly on the concrete file type and
+            /// resolve to `<File as FileExt>::*`.
+            #[test]
+            fn file_ext_blanket_for_ref() {
+                fn drive<F: FileExt + ?Sized>(f: &F, len: u64) {
+                    f.lock_shared().unwrap();
+                    f.unlock().unwrap();
+                    f.lock().unwrap();
+                    f.unlock().unwrap();
+                    f.try_lock_shared().unwrap();
+                    f.unlock().unwrap();
+                    f.try_lock().unwrap();
+                    f.unlock().unwrap();
+                    f.allocate(len).unwrap();
+                    let _ = f.allocated_size().unwrap();
+                }
+
+                let tempdir = tempfile::TempDir::with_prefix("fs4").unwrap();
+                let path = tempdir.path().join("fs4");
+                let file = fs::OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&path)
+                    .unwrap();
+                let blksize = allocation_granularity(&path).unwrap();
+
+                // `&&file` makes the inner `F` bind to `&File`, so all method
+                // calls resolve to the `<&File as FileExt>` blanket impl.
+                drive(&&file, blksize);
+            }
+
             /// Tests shared file lock operations.
             #[test]
             fn lock_shared() {

--- a/src/file_ext/sync_impl.rs
+++ b/src/file_ext/sync_impl.rs
@@ -2,6 +2,8 @@ macro_rules! file_ext {
   ($file:ty, $file_name:literal) => {
     use std::io::Result;
 
+    impl $crate::sealed::Sealed for $file {}
+
     impl $crate::FileExt for $file {
       #[cfg_attr(not(tarpaulin), inline(always))]
       fn allocated_size(&self) -> Result<u64> {

--- a/src/file_ext/sync_impl.rs
+++ b/src/file_ext/sync_impl.rs
@@ -1,106 +1,38 @@
 macro_rules! file_ext {
-    ($file:ty, $file_name:literal) => {
-        use std::io::Result;
+  ($file:ty, $file_name:literal) => {
+    use std::io::Result;
 
-        #[doc = concat!("Extension trait for `", $file_name, "` which provides allocation and locking methods.")]
-        ///
-        /// ## Notes on File Locks
-        ///
-        /// This library provides whole-file locks in both shared (read) and exclusive
-        /// (read-write) varieties.
-        ///
-        /// File locks are a cross-platform hazard since the file lock APIs exposed by
-        /// operating system kernels vary in subtle and not-so-subtle ways.
-        ///
-        /// The API exposed by this library can be safely used across platforms as long
-        /// as the following rules are followed:
-        ///
-        ///   * Multiple locks should not be created on an individual `File` instance
-        ///     concurrently.
-        ///   * Duplicated files should not be locked without great care.
-        ///   * Files to be locked should be opened with at least read or write
-        ///     permissions.
-        ///   * File locks may only be relied upon to be advisory.
-        ///
-        /// File locks are released automatically when the file handle is closed (for
-        /// example when the owning `File` is dropped), so calling [`FileExt::unlock`]
-        /// explicitly is optional.
-        ///
-        /// File locks are implemented with
-        /// [`flock(2)`](http://man7.org/linux/man-pages/man2/flock.2.html) on Unix and
-        /// [`LockFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex)
-        /// on Windows.
-        pub trait FileExt {
-            /// Returns the amount of physical space allocated for a file.
-            fn allocated_size(&self) -> Result<u64>;
-
-            /// Ensures that at least `len` bytes of disk space are allocated for the
-            /// file. After a successful call to `allocate`, subsequent writes to the
-            /// file within the specified length are guaranteed not to fail because of
-            /// lack of disk space.
-            ///
-            /// On most platforms the file's logical size is also extended to `len`
-            /// bytes. On Windows, if the file's existing cluster-aligned allocation
-            /// already covers `len`, the logical size is left unchanged to work around
-            /// buffered-I/O quirks observed when the end-of-file pointer is moved
-            /// inside an already-allocated cluster.
-            fn allocate(&self, len: u64) -> Result<()>;
-
-            /// Acquires a shared lock on the file, blocking until the lock can be
-            /// acquired.
-            fn lock_shared(&self) -> Result<()>;
-
-            /// Acquires an exclusive lock on the file, blocking until the lock can be
-            /// acquired.
-            ///
-            /// This is the blocking counterpart of [`FileExt::try_lock`]. It mirrors
-            /// [`std::fs::File::lock`].
-            fn lock(&self) -> Result<()>;
-
-            /// Attempts to acquire a shared lock on the file, without blocking.
-            ///
-            /// Returns `Ok(())` if the lock was acquired, or
-            /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
-            /// if the file is currently locked. Mirrors
-            /// [`std::fs::File::try_lock_shared`].
-            fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError>;
-
-            /// Attempts to acquire an exclusive lock on the file, without blocking.
-            ///
-            /// Returns `Ok(())` if the lock was acquired, or
-            /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
-            /// if the file is currently locked. Mirrors [`std::fs::File::try_lock`].
-            fn try_lock(&self) -> std::result::Result<(), crate::TryLockError>;
-
-            /// Releases any lock held on the file. The lock is also released
-            /// automatically when the file handle is closed.
-            fn unlock(&self) -> Result<()>;
-        }
-
-        impl FileExt for $file {
-            fn allocated_size(&self) -> Result<u64> {
-                sys::allocated_size(self)
-            }
-            fn allocate(&self, len: u64) -> Result<()> {
-                sys::allocate(self, len)
-            }
-            fn lock_shared(&self) -> Result<()> {
-                sys::lock_shared(self)
-            }
-            fn lock(&self) -> Result<()> {
-                sys::lock(self)
-            }
-            fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError> {
-                sys::try_lock_shared(self)
-            }
-            fn try_lock(&self) -> std::result::Result<(), crate::TryLockError> {
-                sys::try_lock(self)
-            }
-            fn unlock(&self) -> Result<()> {
-                sys::unlock(self)
-            }
-        }
+    impl $crate::FileExt for $file {
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn allocated_size(&self) -> Result<u64> {
+        sys::allocated_size(self)
+      }
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn allocate(&self, len: u64) -> Result<()> {
+        sys::allocate(self, len)
+      }
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn lock_shared(&self) -> Result<()> {
+        sys::lock_shared(self)
+      }
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn lock(&self) -> Result<()> {
+        sys::lock(self)
+      }
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn try_lock_shared(&self) -> std::result::Result<(), $crate::TryLockError> {
+        sys::try_lock_shared(self)
+      }
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn try_lock(&self) -> std::result::Result<(), $crate::TryLockError> {
+        sys::try_lock(self)
+      }
+      #[cfg_attr(not(tarpaulin), inline(always))]
+      fn unlock(&self) -> Result<()> {
+        sys::unlock(self)
+      }
     }
+  };
 }
 
 macro_rules! test_mod {
@@ -109,8 +41,7 @@ macro_rules! test_mod {
         mod test {
             extern crate tempfile;
 
-            use super::*;
-            use crate::{allocation_granularity, statvfs, FsStats, TryLockError};
+            use crate::{allocation_granularity, statvfs, FsStats, TryLockError, FileExt};
 
             $(
                 $use_stmt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,6 @@ pub use fs_stats::FsStats;
 mod try_lock_error;
 pub use try_lock_error::TryLockError;
 
-#[cfg(any(unix, windows))]
 use std::io::Result;
 #[cfg(any(unix, windows))]
 use std::path::Path;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,31 +150,31 @@ pub mod fs_err3 {
 #[cfg(all(feature = "async-std", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
 pub mod async_std {
-  pub use crate::AsyncFileExt;
+  pub use crate::{AsyncFileExt, DynAsyncFileExt};
 }
 
 #[cfg(all(feature = "fs-err2-tokio", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-err2-tokio")))]
 pub mod fs_err2_tokio {
-  pub use crate::AsyncFileExt;
+  pub use crate::{AsyncFileExt, DynAsyncFileExt};
 }
 
 #[cfg(all(feature = "fs-err3-tokio", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-err3-tokio")))]
 pub mod fs_err3_tokio {
-  pub use crate::AsyncFileExt;
+  pub use crate::{AsyncFileExt, DynAsyncFileExt};
 }
 
 #[cfg(all(feature = "smol", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "smol")))]
 pub mod smol {
-  pub use crate::AsyncFileExt;
+  pub use crate::{AsyncFileExt, DynAsyncFileExt};
 }
 
 #[cfg(all(feature = "tokio", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio {
-  pub use crate::AsyncFileExt;
+  pub use crate::{AsyncFileExt, DynAsyncFileExt};
 }
 
 mod fs_stats;
@@ -240,7 +240,15 @@ where
   statvfs(path).map(|stat| stat.allocation_granularity)
 }
 
+mod sealed {
+  pub trait Sealed {}
+
+  impl<F: Sealed + ?Sized> Sealed for &F {}
+}
+
 /// Extension trait for file which provides allocation and locking methods.
+///
+/// This trait is sealed and cannot be implemented for types outside of `fs4`.
 ///
 /// ## Notes on File Locks
 ///
@@ -268,7 +276,7 @@ where
 /// [`flock(2)`](http://man7.org/linux/man-pages/man2/flock.2.html) on Unix and
 /// [`LockFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex)
 /// on Windows.
-pub trait FileExt {
+pub trait FileExt: sealed::Sealed {
   /// Returns the amount of physical space allocated for a file.
   fn allocated_size(&self) -> Result<u64>;
 
@@ -383,7 +391,9 @@ impl<F: FileExt + ?Sized> FileExt for &F {
 /// the underlying system calls are blocking. The separate
 /// [`AsyncFileExt::unlock_async`] method is provided for convenience inside
 /// async code, but the underlying `unlock` syscall is still blocking.
-pub trait AsyncFileExt {
+///
+/// This trait is sealed and cannot be implemented for types outside of `fs4`.
+pub trait AsyncFileExt: sealed::Sealed {
   /// Returns the amount of physical space allocated for a file.
   fn allocated_size(&self) -> impl core::future::Future<Output = Result<u64>>;
 
@@ -472,6 +482,116 @@ impl<F: AsyncFileExt + ?Sized> AsyncFileExt for &F {
   #[cfg_attr(not(tarpaulin), inline(always))]
   async fn unlock_async(&self) -> Result<()> {
     (*self).unlock_async().await
+  }
+}
+
+/// A heap-allocated, dynamically-typed `Send` future used by
+/// [`DynAsyncFileExt`] to keep its methods object-safe.
+pub type BoxFuture<'a, T> = core::pin::Pin<Box<dyn core::future::Future<Output = T> + Send + 'a>>;
+
+/// Object-safe variant of [`AsyncFileExt`] returning boxed `Send` futures, so
+/// it can be used behind a trait object (e.g. `Box<dyn DynAsyncFileExt>` or
+/// `&dyn DynAsyncFileExt`).
+///
+/// [`AsyncFileExt`] uses return-position `impl Future`, which is not
+/// object-safe; this trait wraps the same operations behind
+/// [`BoxFuture`]s so the trait *can* be used as a trait object. Every type
+/// that implements [`AsyncFileExt`] also implements `DynAsyncFileExt`.
+///
+/// Prefer [`AsyncFileExt`] for generic code (no allocation, no dynamic
+/// dispatch); reach for `DynAsyncFileExt` only when type erasure is
+/// required.
+///
+/// This trait is sealed and cannot be implemented for types outside of `fs4`.
+pub trait DynAsyncFileExt: sealed::Sealed {
+  /// Returns the amount of physical space allocated for a file.
+  fn allocated_size(&self) -> BoxFuture<'_, Result<u64>>;
+
+  /// Ensures that at least `len` bytes of disk space are allocated for the
+  /// file. After a successful call to `allocate`, subsequent writes to the
+  /// file within the specified length are guaranteed not to fail because of
+  /// lack of disk space.
+  ///
+  /// On most platforms the file's logical size is also extended to `len`
+  /// bytes. On Windows, if the file's existing cluster-aligned allocation
+  /// already covers `len`, the logical size is left unchanged to work around
+  /// buffered-I/O quirks observed when the end-of-file pointer is moved
+  /// inside an already-allocated cluster.
+  fn allocate(&self, len: u64) -> BoxFuture<'_, Result<()>>;
+
+  /// Acquires a shared lock on the file, blocking until the lock can be
+  /// acquired.
+  fn lock_shared(&self) -> Result<()>;
+
+  /// Acquires an exclusive lock on the file, blocking until the lock can be
+  /// acquired. Mirrors [`std::fs::File::lock`].
+  fn lock(&self) -> Result<()>;
+
+  /// Attempts to acquire a shared lock on the file, without blocking.
+  ///
+  /// Returns `Ok(())` if the lock was acquired, or
+  /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
+  /// if the file is currently locked.
+  fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError>;
+
+  /// Attempts to acquire an exclusive lock on the file, without blocking.
+  ///
+  /// Returns `Ok(())` if the lock was acquired, or
+  /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
+  /// if the file is currently locked.
+  fn try_lock(&self) -> std::result::Result<(), crate::TryLockError>;
+
+  /// Releases any lock held on the file. The lock is also released
+  /// automatically when the file handle is closed.
+  fn unlock(&self) -> Result<()>;
+
+  /// Releases any lock held on the file.
+  ///
+  /// **Note:** This method is not truly async; the underlying system call is
+  /// still blocking. It exists for convenience when used from an async
+  /// context.
+  fn unlock_async(&self) -> BoxFuture<'_, Result<()>>;
+}
+
+impl<F: DynAsyncFileExt + ?Sized> DynAsyncFileExt for &F {
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn allocated_size(&self) -> BoxFuture<'_, Result<u64>> {
+    <F as DynAsyncFileExt>::allocated_size(*self)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn allocate(&self, len: u64) -> BoxFuture<'_, Result<()>> {
+    <F as DynAsyncFileExt>::allocate(*self, len)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn lock_shared(&self) -> Result<()> {
+    <F as DynAsyncFileExt>::lock_shared(*self)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn lock(&self) -> Result<()> {
+    <F as DynAsyncFileExt>::lock(*self)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError> {
+    <F as DynAsyncFileExt>::try_lock_shared(*self)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn try_lock(&self) -> std::result::Result<(), crate::TryLockError> {
+    <F as DynAsyncFileExt>::try_lock(*self)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn unlock(&self) -> Result<()> {
+    <F as DynAsyncFileExt>::unlock(*self)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn unlock_async(&self) -> BoxFuture<'_, Result<()>> {
+    <F as DynAsyncFileExt>::unlock_async(*self)
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,50 +135,46 @@ use windows as sys;
 #[cfg(any(unix, windows))]
 mod file_ext;
 
-#[cfg(all(feature = "sync", any(unix, windows)))]
-#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
-pub use crate::file_ext::sync_impl::std_impl::FileExt;
-
 #[cfg(all(feature = "fs-err2", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-err2")))]
 pub mod fs_err2 {
-  pub use crate::file_ext::sync_impl::fs_err2_impl::FileExt;
+  pub use crate::FileExt;
 }
 
 #[cfg(all(feature = "fs-err3", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-err3")))]
 pub mod fs_err3 {
-  pub use crate::file_ext::sync_impl::fs_err3_impl::FileExt;
+  pub use crate::FileExt;
 }
 
 #[cfg(all(feature = "async-std", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-std")))]
 pub mod async_std {
-  pub use crate::file_ext::async_impl::async_std_impl::AsyncFileExt;
+  pub use crate::AsyncFileExt;
 }
 
 #[cfg(all(feature = "fs-err2-tokio", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-err2-tokio")))]
 pub mod fs_err2_tokio {
-  pub use crate::file_ext::async_impl::fs_err2_tokio_impl::AsyncFileExt;
+  pub use crate::AsyncFileExt;
 }
 
 #[cfg(all(feature = "fs-err3-tokio", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "fs-err3-tokio")))]
 pub mod fs_err3_tokio {
-  pub use crate::file_ext::async_impl::fs_err3_tokio_impl::AsyncFileExt;
+  pub use crate::AsyncFileExt;
 }
 
 #[cfg(all(feature = "smol", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "smol")))]
 pub mod smol {
-  pub use crate::file_ext::async_impl::smol_impl::AsyncFileExt;
+  pub use crate::AsyncFileExt;
 }
 
 #[cfg(all(feature = "tokio", any(unix, windows)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod tokio {
-  pub use crate::file_ext::async_impl::tokio_impl::AsyncFileExt;
+  pub use crate::AsyncFileExt;
 }
 
 mod fs_stats;
@@ -242,6 +238,241 @@ where
   P: AsRef<Path>,
 {
   statvfs(path).map(|stat| stat.allocation_granularity)
+}
+
+/// Extension trait for file which provides allocation and locking methods.
+///
+/// ## Notes on File Locks
+///
+/// This library provides whole-file locks in both shared (read) and exclusive
+/// (read-write) varieties.
+///
+/// File locks are a cross-platform hazard since the file lock APIs exposed by
+/// operating system kernels vary in subtle and not-so-subtle ways.
+///
+/// The API exposed by this library can be safely used across platforms as long
+/// as the following rules are followed:
+///
+///   * Multiple locks should not be created on an individual `File` instance
+///     concurrently.
+///   * Duplicated files should not be locked without great care.
+///   * Files to be locked should be opened with at least read or write
+///     permissions.
+///   * File locks may only be relied upon to be advisory.
+///
+/// File locks are released automatically when the file handle is closed (for
+/// example when the owning `File` is dropped), so calling [`FileExt::unlock`]
+/// explicitly is optional.
+///
+/// File locks are implemented with
+/// [`flock(2)`](http://man7.org/linux/man-pages/man2/flock.2.html) on Unix and
+/// [`LockFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex)
+/// on Windows.
+pub trait FileExt {
+  /// Returns the amount of physical space allocated for a file.
+  fn allocated_size(&self) -> Result<u64>;
+
+  /// Ensures that at least `len` bytes of disk space are allocated for the
+  /// file. After a successful call to `allocate`, subsequent writes to the
+  /// file within the specified length are guaranteed not to fail because of
+  /// lack of disk space.
+  ///
+  /// On most platforms the file's logical size is also extended to `len`
+  /// bytes. On Windows, if the file's existing cluster-aligned allocation
+  /// already covers `len`, the logical size is left unchanged to work around
+  /// buffered-I/O quirks observed when the end-of-file pointer is moved
+  /// inside an already-allocated cluster.
+  fn allocate(&self, len: u64) -> Result<()>;
+
+  /// Acquires a shared lock on the file, blocking until the lock can be
+  /// acquired.
+  fn lock_shared(&self) -> Result<()>;
+
+  /// Acquires an exclusive lock on the file, blocking until the lock can be
+  /// acquired.
+  ///
+  /// This is the blocking counterpart of [`FileExt::try_lock`]. It mirrors
+  /// [`std::fs::File::lock`].
+  fn lock(&self) -> Result<()>;
+
+  /// Attempts to acquire a shared lock on the file, without blocking.
+  ///
+  /// Returns `Ok(())` if the lock was acquired, or
+  /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
+  /// if the file is currently locked. Mirrors
+  /// [`std::fs::File::try_lock_shared`].
+  fn try_lock_shared(&self) -> std::result::Result<(), TryLockError>;
+
+  /// Attempts to acquire an exclusive lock on the file, without blocking.
+  ///
+  /// Returns `Ok(())` if the lock was acquired, or
+  /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
+  /// if the file is currently locked. Mirrors [`std::fs::File::try_lock`].
+  fn try_lock(&self) -> std::result::Result<(), TryLockError>;
+
+  /// Releases any lock held on the file. The lock is also released
+  /// automatically when the file handle is closed.
+  fn unlock(&self) -> Result<()>;
+}
+
+impl<F: FileExt + ?Sized> FileExt for &F {
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn allocated_size(&self) -> Result<u64> {
+    (*self).allocated_size()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn allocate(&self, len: u64) -> Result<()> {
+    (*self).allocate(len)
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn lock_shared(&self) -> Result<()> {
+    (*self).lock_shared()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn lock(&self) -> Result<()> {
+    (*self).lock()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn try_lock_shared(&self) -> std::result::Result<(), TryLockError> {
+    (*self).try_lock_shared()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn try_lock(&self) -> std::result::Result<(), TryLockError> {
+    (*self).try_lock()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn unlock(&self) -> Result<()> {
+    (*self).unlock()
+  }
+}
+
+/// Extension trait for file which provides allocation and locking methods.
+///
+/// ## Notes on File Locks
+///
+/// This library provides whole-file locks in both shared (read) and exclusive
+/// (read-write) varieties.
+///
+/// File locks are a cross-platform hazard since the file lock APIs exposed by
+/// operating system kernels vary in subtle and not-so-subtle ways.
+///
+/// The API exposed by this library can be safely used across platforms as long
+/// as the following rules are followed:
+///
+///   * Multiple locks should not be created on an individual `File` instance
+///     concurrently.
+///   * Duplicated files should not be locked without great care.
+///   * Files to be locked should be opened with at least read or write
+///     permissions.
+///   * File locks may only be relied upon to be advisory.
+///
+/// File locks are released automatically when the file handle is closed (for
+/// example when the owning `File` is dropped), so calling [`AsyncFileExt::unlock`]
+/// explicitly is optional.
+///
+/// File locks are implemented with
+/// [`flock(2)`](http://man7.org/linux/man-pages/man2/flock.2.html) on Unix and
+/// [`LockFileEx`](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-lockfileex)
+/// on Windows. The `lock_*` and `try_lock_*` methods are synchronous because
+/// the underlying system calls are blocking. The separate
+/// [`AsyncFileExt::unlock_async`] method is provided for convenience inside
+/// async code, but the underlying `unlock` syscall is still blocking.
+pub trait AsyncFileExt {
+  /// Returns the amount of physical space allocated for a file.
+  fn allocated_size(&self) -> impl core::future::Future<Output = Result<u64>>;
+
+  /// Ensures that at least `len` bytes of disk space are allocated for the
+  /// file. After a successful call to `allocate`, subsequent writes to the
+  /// file within the specified length are guaranteed not to fail because of
+  /// lack of disk space.
+  ///
+  /// On most platforms the file's logical size is also extended to `len`
+  /// bytes. On Windows, if the file's existing cluster-aligned allocation
+  /// already covers `len`, the logical size is left unchanged to work around
+  /// buffered-I/O quirks observed when the end-of-file pointer is moved
+  /// inside an already-allocated cluster.
+  fn allocate(&self, len: u64) -> impl core::future::Future<Output = Result<()>>;
+
+  /// Acquires a shared lock on the file, blocking until the lock can be
+  /// acquired.
+  fn lock_shared(&self) -> Result<()>;
+
+  /// Acquires an exclusive lock on the file, blocking until the lock can be
+  /// acquired. Mirrors [`std::fs::File::lock`].
+  fn lock(&self) -> Result<()>;
+
+  /// Attempts to acquire a shared lock on the file, without blocking.
+  ///
+  /// Returns `Ok(())` if the lock was acquired, or
+  /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
+  /// if the file is currently locked.
+  fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError>;
+
+  /// Attempts to acquire an exclusive lock on the file, without blocking.
+  ///
+  /// Returns `Ok(())` if the lock was acquired, or
+  /// `Err(`[`TryLockError::WouldBlock`](crate::TryLockError::WouldBlock)`)`
+  /// if the file is currently locked.
+  fn try_lock(&self) -> std::result::Result<(), crate::TryLockError>;
+
+  /// Releases any lock held on the file. The lock is also released
+  /// automatically when the file handle is closed.
+  fn unlock(&self) -> Result<()>;
+
+  /// Releases any lock held on the file.
+  ///
+  /// **Note:** This method is not truly async; the underlying system call is
+  /// still blocking. It exists for convenience when used from an async
+  /// context.
+  fn unlock_async(&self) -> impl core::future::Future<Output = Result<()>>;
+}
+
+impl<F: AsyncFileExt + ?Sized> AsyncFileExt for &F {
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  async fn allocated_size(&self) -> Result<u64> {
+    (*self).allocated_size().await
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  async fn allocate(&self, len: u64) -> Result<()> {
+    (*self).allocate(len).await
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn lock_shared(&self) -> Result<()> {
+    (*self).lock_shared()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn lock(&self) -> Result<()> {
+    (*self).lock()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError> {
+    (*self).try_lock_shared()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn try_lock(&self) -> std::result::Result<(), crate::TryLockError> {
+    (*self).try_lock()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  fn unlock(&self) -> Result<()> {
+    (*self).unlock()
+  }
+
+  #[cfg_attr(not(tarpaulin), inline(always))]
+  async fn unlock_async(&self) -> Result<()> {
+    (*self).unlock_async().await
+  }
 }
 
 #[cfg(all(test, any(unix, windows)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,37 +325,37 @@ pub trait FileExt: sealed::Sealed {
 impl<F: FileExt + ?Sized> FileExt for &F {
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn allocated_size(&self) -> Result<u64> {
-    (*self).allocated_size()
+    <F as FileExt>::allocated_size(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn allocate(&self, len: u64) -> Result<()> {
-    (*self).allocate(len)
+    <F as FileExt>::allocate(*self, len)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn lock_shared(&self) -> Result<()> {
-    (*self).lock_shared()
+    <F as FileExt>::lock_shared(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn lock(&self) -> Result<()> {
-    (*self).lock()
+    <F as FileExt>::lock(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn try_lock_shared(&self) -> std::result::Result<(), TryLockError> {
-    (*self).try_lock_shared()
+    <F as FileExt>::try_lock_shared(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn try_lock(&self) -> std::result::Result<(), TryLockError> {
-    (*self).try_lock()
+    <F as FileExt>::try_lock(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn unlock(&self) -> Result<()> {
-    (*self).unlock()
+    <F as FileExt>::unlock(*self)
   }
 }
 
@@ -445,42 +445,42 @@ pub trait AsyncFileExt: sealed::Sealed {
 impl<F: AsyncFileExt + ?Sized> AsyncFileExt for &F {
   #[cfg_attr(not(tarpaulin), inline(always))]
   async fn allocated_size(&self) -> Result<u64> {
-    (*self).allocated_size().await
+    <F as AsyncFileExt>::allocated_size(*self).await
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   async fn allocate(&self, len: u64) -> Result<()> {
-    (*self).allocate(len).await
+    <F as AsyncFileExt>::allocate(*self, len).await
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn lock_shared(&self) -> Result<()> {
-    (*self).lock_shared()
+    <F as AsyncFileExt>::lock_shared(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn lock(&self) -> Result<()> {
-    (*self).lock()
+    <F as AsyncFileExt>::lock(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn try_lock_shared(&self) -> std::result::Result<(), crate::TryLockError> {
-    (*self).try_lock_shared()
+    <F as AsyncFileExt>::try_lock_shared(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn try_lock(&self) -> std::result::Result<(), crate::TryLockError> {
-    (*self).try_lock()
+    <F as AsyncFileExt>::try_lock(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   fn unlock(&self) -> Result<()> {
-    (*self).unlock()
+    <F as AsyncFileExt>::unlock(*self)
   }
 
   #[cfg_attr(not(tarpaulin), inline(always))]
   async fn unlock_async(&self) -> Result<()> {
-    (*self).unlock_async().await
+    <F as AsyncFileExt>::unlock_async(*self).await
   }
 }
 

--- a/src/unix/async_impl.rs
+++ b/src/unix/async_impl.rs
@@ -72,7 +72,7 @@ macro_rules! test_mod {
         mod test {
           extern crate tempfile;
 
-          use crate::TryLockError;
+          use crate::{TryLockError, AsyncFileExt};
 
           $(
               $use_stmt

--- a/src/unix/async_impl/async_std_impl.rs
+++ b/src/unix/async_impl/async_std_impl.rs
@@ -8,6 +8,5 @@ allocate_size!(File);
 
 test_mod! {
   async_std::test,
-  use crate::async_std::AsyncFileExt;
   use async_std::fs;
 }

--- a/src/unix/async_impl/fs_err2_tokio_impl.rs
+++ b/src/unix/async_impl/fs_err2_tokio_impl.rs
@@ -8,6 +8,5 @@ allocate_size!(File);
 
 test_mod! {
   tokio::test,
-  use crate::fs_err2_tokio::AsyncFileExt;
   use fs_err2::tokio as fs;
 }

--- a/src/unix/async_impl/fs_err3_tokio_impl.rs
+++ b/src/unix/async_impl/fs_err3_tokio_impl.rs
@@ -8,6 +8,5 @@ allocate_size!(File);
 
 test_mod! {
   tokio::test,
-  use crate::fs_err3_tokio::AsyncFileExt;
   use fs_err3::tokio as fs;
 }

--- a/src/unix/async_impl/smol_impl.rs
+++ b/src/unix/async_impl/smol_impl.rs
@@ -8,6 +8,5 @@ allocate_size!(File);
 
 test_mod! {
   smol_potat::test,
-  use crate::smol::AsyncFileExt;
   use smol::fs;
 }

--- a/src/unix/async_impl/tokio_impl.rs
+++ b/src/unix/async_impl/tokio_impl.rs
@@ -8,6 +8,5 @@ allocate_size!(File);
 
 test_mod! {
   tokio::test,
-  use crate::tokio::AsyncFileExt;
   use tokio::fs;
 }


### PR DESCRIPTION
## Summary

Unify the per-backend `FileExt` / `AsyncFileExt` traits into a single crate-root trait, seal both, and add an object-safe `DynAsyncFileExt` mirror so callers can hold fs4 file handles behind `dyn` (e.g. `Box<dyn DynAsyncFileExt>`).

- **Single crate-root traits.** Previously the `file_ext!` / `async_file_ext!` macros generated a fresh `pub trait FileExt` / `AsyncFileExt` per backend module, so `fs4::tokio::AsyncFileExt` and `fs4::async_std::AsyncFileExt` were *distinct types*. Now there is one `fs4::FileExt` and one `fs4::AsyncFileExt` defined directly in `lib.rs`; the per-backend modules (`fs4::tokio`, `fs4::async_std`, `fs4::smol`, `fs4::fs_err2`, `fs4::fs_err3`, `fs4::fs_err2_tokio`, `fs4::fs_err3_tokio`) re-export the unified trait. Method-call sites that imported the trait via `use` continue to compile unchanged.
- **Reference blanket impls.** New `impl<F: FileExt + ?Sized> FileExt for &F` and `impl<F: AsyncFileExt + ?Sized> AsyncFileExt for &F`, so the extension methods are now callable through shared references.
- **Sealed.** `FileExt`, `AsyncFileExt`, and `DynAsyncFileExt` now carry a private `sealed::Sealed` supertrait; the implementing set is closed to the concrete file types fs4 supports plus their `&` references.
- **`DynAsyncFileExt`.** `AsyncFileExt` uses RPITIT (`-> impl Future<Output = ...>`) and is therefore not object-safe. The new `DynAsyncFileExt` mirrors the same operations behind `BoxFuture<'_, T>` (a `pub type` alias for `Pin<Box<dyn Future<Output = T> + Send + 'a>>`) so it *can* be used as a trait object (`Box<dyn DynAsyncFileExt>`, `&dyn DynAsyncFileExt`). The impl is generated per-backend in the `async_file_ext!` macro so each concrete file type's `Send`-ness is checked at build time. Includes its own `&F` blanket impl. Sealed. Re-exported alongside `AsyncFileExt` from each async backend submodule.
- **`#[inline(always)]`** on the thin delegating methods (excluded under `tarpaulin`).
- **rustfmt**: add `imports_granularity = \"Crate\"`.

`FileExt` (sync) is already object-safe — all methods return concrete `Result<T>` — so no `DynFileExt` is needed; `dyn FileExt` works directly. The crate continues to compile on `wasm32-wasi*` (which has neither `cfg(unix)` nor `cfg(windows)`); on those targets it degrades to just `FsStats` + `TryLockError` as before.

### Semver

Minor bump (1.1.0). The new blanket impls and `DynAsyncFileExt` are additions. Trait-identity unification (the per-backend traits are now the same trait) and the new `Sealed` supertrait can in principle break downstream code that relied on the distinctness of the per-backend traits or implemented `FileExt`/`AsyncFileExt` on its own wrapper type — both patterns are uncommon in practice. The mainstream consumer pattern (calling methods through `use fs4::<backend>::{FileExt,AsyncFileExt}`) is preserved.

Full details in [CHANGELOG.md](CHANGELOG.md).

## Test plan

- [x] \`cargo check --all-features\`
- [x] \`cargo check --no-default-features\`
- [x] \`cargo check --all-features --tests\`
- [x] \`cargo check --target wasm32-wasip1\` and \`cargo check --target wasm32-wasip1 --no-default-features\`
- [x] \`cargo test --all-features --lib\` (90 passing)
- [ ] CI matrix green (ubuntu / macos / windows, MSRV 1.75 + each-feature)